### PR TITLE
fix: 允许跨域的 DELETE 请求方法

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -9,7 +9,7 @@ app.use(express.json())
 app.use('/api', (req, res, next) => {
   res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Headers', '*')
-  res.setHeader('Access-Control-Allow-Methods', 'post, get, options')
+  res.setHeader('Access-Control-Allow-Methods', 'post, get, options, delete')
   next()
 }, ApiRouter)
 

--- a/backend/e2e/post.images.test.js
+++ b/backend/e2e/post.images.test.js
@@ -79,6 +79,18 @@ describe('post images 上传图片', () => {
     expect(res).not.toEqual(undefined)
   })
 
+  // https://github.com/Jiang-Xuan/tuchuang.space/issues/83
+  it('当浏览器跨域请求 OPTIONS 时, 需要返回响应的跨域响应头', async () => {
+    // act
+    const response = await request(app)
+      .options('/api/v1/images')
+
+    // assert
+    expect(response.header['access-control-allow-methods']).toEqual('post, get, options, delete')
+    expect(response.header['access-control-allow-origin']).toEqual('*')
+    expect(response.header['access-control-allow-headers']).toEqual('*')
+  })
+
   it('当文件超出 MAX_FILES 的时候抛出错误', async () => {
     const filePath = path.resolve(__dirname, '../../shared/test_images/png.png')
     const resHandler = request(app)


### PR DESCRIPTION
fix #83 