### PR TITLE
fix: cors access-control-allow-methods 为大小写敏感 case-sensitive

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -9,7 +9,7 @@ app.use(express.json())
 app.use('/api', (req, res, next) => {
   res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Headers', '*')
-  res.setHeader('Access-Control-Allow-Methods', 'post, get, options, delete')
+  res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS, DELETE')
   next()
 }, ApiRouter)
 

--- a/backend/e2e/post.images.test.js
+++ b/backend/e2e/post.images.test.js
@@ -86,7 +86,7 @@ describe('post images 上传图片', () => {
       .options('/api/v1/images')
 
     // assert
-    expect(response.header['access-control-allow-methods']).toEqual('post, get, options, delete')
+    expect(response.header['access-control-allow-methods']).toEqual('POST, GET, OPTIONS, DELETE')
     expect(response.header['access-control-allow-origin']).toEqual('*')
     expect(response.header['access-control-allow-headers']).toEqual('*')
   })


### PR DESCRIPTION
fix #91 